### PR TITLE
Fix header rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Apollo server subscriptions on AWS Lambda
+## Apollo server subscriptions on AWS Lambda
 
 This is an example application which shows how to implement apollo-server-lambda with subscriptions.
 For subscriptions implementation AWS API Gateway Websockets and DynamoDB were used


### PR DESCRIPTION
This adds a single ` ` space character after the h2 level header characters (`##`) so that the markdown renderer will recognize it correctly and display the header correctly.

[See formatting diff](https://github.com/AlpacaGoesCrazy/serverless-graphql-subscriptions/pull/22/commits/e21597dc7d0eee15d8ba680453fe088796ce85d9?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)